### PR TITLE
cd: Changed to use release tag name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,4 +26,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.ref_name }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.event.release.tag_name }}


### PR DESCRIPTION
# PR docker-cd

## What kmom

- kmom01

## Whats changed

CD: Changed to use the github.event.release.tag_name for docker image version instead of github.ref_name

## What issus are solved, if any

[cd: Docker imahge publish CD implementation #7](https://github.com/FalkenDev/microblog/pull/7)
