### PR TITLE
cd: Added docker image publish for test and prod

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
           file: ./docker/Dockerfile_prod
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.event.release.tag_name }}-prod
 
-      - name: Build and push Docker image for production
+      - name: Build and push Docker image for testing
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,8 +22,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image for production
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.event.release.tag_name }}
+          file: ./docker/Dockerfile_prod
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.event.release.tag_name }}-prod
+
+      - name: Build and push Docker image for production
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./docker/Dockerfile_prod
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/microblog:${{ github.event.release.tag_name }}-test


### PR DESCRIPTION
It now publish both a test docker image and prod docker image to dockerhub.

# PR docker-cd

## What kmom

kmom01

## Whats changed

cd: It now publish both a test docker image and prod docker image to dockerhub.

## What issus are solved, if any

[cd: Changed to use release tag name #8](https://github.com/FalkenDev/microblog/pull/8)
[cd: Docker imahge publish CD implementation #7](https://github.com/FalkenDev/microblog/pull/7)
