### PR TITLE
Added Bandit test CI to find possible security holes in the Python code

### DIFF
--- a/.github/workflows/BTD-ci.yml
+++ b/.github/workflows/BTD-ci.yml
@@ -1,0 +1,33 @@
+name: Bandit, Trivy, and Dockle
+
+on:
+  workflow_call:
+  release:
+    types: [created]
+
+jobs:
+  BTD:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install make
+
+      - name: Run Bandit
+        run: bandit-test
+
+      - name: Run Trivy
+        run: trivy-test
+
+      - name: Run Dockle
+        run: dockle-test

--- a/.github/workflows/BTD-ci.yml
+++ b/.github/workflows/BTD-ci.yml
@@ -22,12 +22,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install make
+          pip install bandit
 
       - name: Run Bandit
         run: bandit-test
 
-      - name: Run Trivy
-        run: trivy-test
+      # - name: Run Trivy
+      #   run: trivy-test
 
-      - name: Run Dockle
-        run: dockle-test
+      # - name: Run Dockle
+      #   run: dockle-test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,8 +9,11 @@ jobs:
   python-ci:
     uses: ./.github/workflows/python-ci.yml
 
+  BTD-ci:
+    uses: ./.github/workflows/BTD-ci.yml
+
   build-and-push:
-    needs: python-ci
+    needs: [python-ci, BTD-ci]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -216,3 +216,10 @@ install-test:
 install-deploy:
 	${pip} install -r requirements/deploy.txt
 	cd ansible && ansible-galaxy install -r requirements.yml
+
+
+
+# target: bandit-test					 - Run SAST tool bandit to find security holes in the code. Skipping hashlib (B324) as it's false positive.
+.PHONY: bandit-test
+bandit-test:
+	bandit  -s B324 app/*.py app/auth/*.py app/errors/*.py app/main/*.py

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@
 pylint >= 2.15.4
 pytest >= 6.1.2
 coverage~=4.5.4
+bandit >= 1.7.5


### PR DESCRIPTION
# PR Bandit Test

## What kmom
- Kmom03

## Whats changed
- Added a script in Makefile to run the bandit. Skipping hashlib (B324) as it's false positive.
- Added bandit to requirments in test requirments.
- Added CI Workflow for test BTD (Bandit, Trivy and Dockle)
- Changed docker-publish CD workflow to run and pass the CI BTD (Bandit, Trivy and Dockle) before publish